### PR TITLE
\#1: Add warning logging for legacy endpoints

### DIFF
--- a/src/xai_grok/grok.py
+++ b/src/xai_grok/grok.py
@@ -47,6 +47,7 @@ class Grok:
 
     def complete(self, request: schemas.CompleteRequest) -> schemas.CompleteResponse:
         endpoint = "v1/complete"
+        self.logger.warning("Using legacy endpoint: POST https://api.x.ai/v1/messages")
         response = self._send_request(
             http.HTTPMethod.POST,
             endpoint,
@@ -62,6 +63,10 @@ class Grok:
 
     def completions(self, request: schemas.SampleRequest) -> schemas.SampleResponse:
         endpoint = "v1/completions"
+        self.logger.warning(
+            "Using legacy endpoint: POST https://api.x.ai/v1/completions. "
+            "This endpoint is deprecated, please use POST https://api.x.ai/v1/chat/completions instead."
+        )
         response = self._send_request(
             http.HTTPMethod.POST,
             endpoint,


### PR DESCRIPTION
  * Add warning for legacy endpoint /v1/complete to use /v1/messages instead
  * Add warning for legacy endpoint /v1/completions to use /v1/chat/completions instead

  Additional Reference: https://api.x.ai/docs
  
Add WARNING logs for legacy endpoints.

Endpoints:

POST https://api.x.ai/v1/complete
POST https://api.x.ai/v1/completions

<img width="1420" alt="Screenshot 2025-01-04 at 9 46 12 PM" src="https://github.com/user-attachments/assets/69f84eaf-e5c3-4809-a0ac-721f2684c50d" />

For POST https://api.x.ai/v1/completions also mention that is deprecated and the endpoint POST https://api.x.ai/v1/chat/completions should be used instead in the WARNING log message.